### PR TITLE
chore(readme): fix readme import

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm i react-wrap-balancer
 And wrap any text with it:
 
 ```jsx
-import { Balancer } from 'react-wrap-balancer'
+import Balancer from 'react-wrap-balancer'
 
 // ...
 


### PR DESCRIPTION
This PR: 

* Fixes the code example which seems to use named exports. It seems that the package currently just has a default export and trying to import `Balancer` as a named export results in the following problem: 

```typescript
Module '"react-wrap-balancer"' has no exported member 'Balancer'. Did you mean to use 'import Balancer from "react-wrap-balancer"' instead?ts(2614)
```

Notes:
* Hope this PR is ok to make, not sure if named exports are planned to be released soon!