### PR TITLE
Ignore hydration warning on script

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -141,6 +141,7 @@ const Balancer: React.FC<Props> = ({
         {children}
       </As>
       <script
+        suppressHydrationWarning={true}
         dangerouslySetInnerHTML={{
           // Calculate the balance initially for SSR
           __html: `self.${SYMBOL_KEY}=${MINIFIED_RELAYOUT_STR};self.${SYMBOL_KEY}("${id}",${ratio})`,


### PR DESCRIPTION
This is a temporary fix for #7
It adds the `suppressHydrationWarning` to the `<script>` block, so it doesn't report the minified code mismatch between client and server as an error.

Ideally it would be built in another way to avoid the mismatch - Maybe by hardcoding the string for the script HTML?