### PR TITLE
Demo: Remove align prop

### DIFF
--- a/website/app/page.js
+++ b/website/app/page.js
@@ -421,7 +421,6 @@ export default function () {
         <Balancer>Useful in tooltips and other UI components</Balancer>
       </h3>
       <Comparison
-        align='left'
         a={
           <>
             <h2 className='item'>


### PR DESCRIPTION
The `<Comparison />` component `align` prop is set to `left` as default. We can safely remove this.