### PR TITLE
fix: github link in safari

### DIFF
--- a/website/app/style.css
+++ b/website/app/style.css
@@ -75,8 +75,8 @@ body {
 .github-link span {
   display: inline-flex;
   align-items: center;
-  flex-shrink: 0;
   gap: 0.2em;
+  white-space: nowrap;
 }
 
 .installation {

--- a/website/app/style.css
+++ b/website/app/style.css
@@ -75,6 +75,7 @@ body {
 .github-link span {
   display: inline-flex;
   align-items: center;
+  flex-shrink: 0;
   gap: 0.2em;
 }
 


### PR DESCRIPTION
In Safari, the Github text wraps to two lines. Adds `flex-shrink` to css to prevent this.

![image](https://user-images.githubusercontent.com/1432193/213806099-761ab0cf-46c8-428d-b7ee-07e30a683096.png)
