### PR TITLE
Fix incorrect width computation for text that can't wrap

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,6 +45,10 @@ const relayout: RelayoutFn = (id, ratio, wrapper) => {
   let middle: number
 
   if (width) {
+    // Ensure we don't search widths lower than when the text overflows
+    update(lower)
+    lower = Math.max(wrapper.scrollWidth, lower)
+
     while (lower + 1 < upper) {
       middle = Math.round((lower + upper) / 2)
       update(middle)


### PR DESCRIPTION
Some reproductions of the issue: https://codesandbox.io/s/react-wrap-balancer-bug-ubbizi

The problem is that if the text can't wrap, the container's height will never change as we shrink the wrapper. So we keep shrinking the wrapper, never observe a height change, and end up with a width lower than the minimum required to not overflow the container.

I solved it by making sure `lower` is no less than the minimum width necessary to fit the contents (see [`scrollWidth` documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth)).

Ideally you wouldn't give `react-wrap-balancer` text that can't wrap in the first place, but sometimes you're getting arbitrary titles from somewhere and you don't know if they are single words or have non-breaking spaces so we should probably handle this case in the package.