### PR TITLE
feat: react under 18 support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "typescript": "^4.8.4"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": ">=16.8.0 || ^17.0.0 || ^18"
   }
 }

--- a/src/id/useId.tsx
+++ b/src/id/useId.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { useState } from "react";
+
+const IS_SERVER = typeof window === "undefined";
+const useIsomorphicLayoutEffect = IS_SERVER
+  ? React.useEffect
+  : React.useLayoutEffect;
+
+let ID = 0;
+const genId = () => {
+  ID += 1;
+  return ID;
+};
+let serverHandoffComplete = false;
+
+function useIdPolyfill() {
+  const [id, setId] = useState(serverHandoffComplete ? genId : undefined);
+
+  useIsomorphicLayoutEffect(() => {
+    if (id === undefined) {
+      ID += 1;
+      setId(ID);
+    }
+
+    serverHandoffComplete = true;
+  }, []);
+
+  if (id === undefined) {
+    return id;
+  }
+
+  return `rwb-${id.toString(32)}`;
+}
+
+/**
+ * A hook for generating unique IDs that are stable across the server and client,
+ * while avoiding hydration mismatches. Compatible with React 16+ by using
+ * [React 18's useId](https://reactjs.org/docs/hooks-reference.html#useid) if
+ * it's available, and a polyfill implementation inspired by
+ * [@accessible/use-id](https://github.com/accessible-ui/use-id) if it is not.
+ *
+ * "rwb-" is hard-coded as a prefix in the polyfill. When using React 18+,
+ * a prefix can be provided with the `identifierPrefix` option in
+ * [ReactDOMClient](https://reactjs.org/docs/react-dom-client.html).
+ */
+export function useId() {
+  const implementation = React.useMemo((): (() => string | number) => {
+    if ("useId" in React) return React.useId;
+    return useIdPolyfill;
+  }, []);
+
+  return implementation();
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { useId } from './id/useId'
 
 const SYMBOL_KEY = '__wrap_b'
 const SYMBOL_OBSERVER_KEY = '__wrap_o'
@@ -133,7 +134,7 @@ const Balancer = <ElementType extends React.ElementType = React.ElementType>({
   children,
   ...props
 }: BalancerProps<ElementType>) => {
-  const id = React.useId()
+  const id = useId()
   const wrapperRef = React.useRef<WrapperElement>()
   const hasProvider = React.useContext(BalancerContext)
   const Wrapper: React.ElementType = props.as || 'span';

--- a/website/src/sections/GettingStarted.tsx
+++ b/website/src/sections/GettingStarted.tsx
@@ -127,7 +127,7 @@ export default function GettingStarted() {
       </div>
       <p>
         <label>Requirements</label>
-        This library requires React ≥ 18.0.0, and IE 11 is not supported.
+        This library requires React ≥ 16.8.0, and IE 11 is not supported.
       </p>
       <p>
         <BlankLink


### PR DESCRIPTION
implement #38 

Thank you for providing a good library.

We only use the function `useId` which react 18 gave, but it is regrettable that the user under react18 version cannot use `react-wrap-balancer`.
I tried to modify the code to make useId polyfill to satisfy past version.

Thank you.