### PR TITLE
Add `preferNative` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ function Title() {
 
 - **`as`** (_optional_): The HTML tag to be used to wrap the text content. Default to `span`.
 - **`ratio`** (_optional_): The ratio of “balance-ness”, 0 <= ratio <= 1. Default to `1`.
+- **`preferNative`** (_optional_): An option to skip the re-balance logic and use the native CSS text-balancing if supported. Default to `true`.
 - **`nonce`** (_optional_): The [nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) attribute to allowlist inline script injection by the component.
 
 ### `<Provider>`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -184,7 +184,7 @@ const Provider: React.FC<{
 
 const Balancer = <ElementType extends React.ElementType = React.ElementType>({
   ratio = 1,
-  preferNative = true,
+  preferNative,
   nonce,
   children,
   ...props
@@ -192,7 +192,7 @@ const Balancer = <ElementType extends React.ElementType = React.ElementType>({
   const id = useId()
   const wrapperRef = React.useRef<WrapperElement>()
   const contextValue = React.useContext(BalancerContext)
-  const preferNativeBalancing = preferNative && contextValue.preferNative
+  const preferNativeBalancing = preferNative ?? contextValue.preferNative
   const Wrapper: React.ElementType = props.as || 'span'
 
   // Re-balance on content change and on mount/hydration.

--- a/website/src/sections/CustomBalanceRatio.tsx
+++ b/website/src/sections/CustomBalanceRatio.tsx
@@ -44,11 +44,13 @@ export default function CustomBalanceRatio() {
                 </Balancer>
               </h2>
               <h2 className='ratio-title'>
-                <Balancer ratio={currentRatio}>
+                <Balancer ratio={currentRatio} preferNative={false}>
                   The quick brown fox jumps over the lazy dog
                 </Balancer>
               </h2>
-              <code>{`<Balancer ratio={${ratio.toFixed(2)}}>`}</code>
+              <code>{`<Balancer ratio={${ratio.toFixed(
+                2
+              )}} preferNative={false}>`}</code>
             </div>
           </div>
         </div>
@@ -88,7 +90,8 @@ export default function CustomBalanceRatio() {
           text-wrap: balance
         </BlankLink>
         ) is available, React Wrap Balancer will use it instead. And the `ratio`
-        option will be ignored in that case.
+        option will be ignored in that case. You can provide the `preferNative`
+        option to opt out.
       </p>
     </>
   )


### PR DESCRIPTION
Provide an option to opt out of the native CSS text-balancing when the `text-wrap: balance` can't serve the needs or a customized ratio is preferred.

Closes https://github.com/shuding/react-wrap-balancer/issues/75.