### PR TITLE
Remove explicit `children:` typing in `BalancerOwnProps`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -140,7 +140,6 @@ interface BalancerOwnProps<
    * The nonce attribute to allowlist inline script injection by the component.
    */
   nonce?: string
-  children?: React.ReactNode
 }
 
 type BalancerProps<ElementType extends React.ElementType> =


### PR DESCRIPTION
Since `children` is inherited from `React.HTMLAttributes<ElementType>` anyway, the re-definition risks conflicts with projects that may extend this type.

For example, `react-i18next` allows users to opt-in to extending `children: ...` to allow for variable insertion in its `<Trans>` components: https://github.com/i18next/react-i18next/blob/master/index.d.ts#L47-L57

By removing the `children: ...` specification here in favor of the inherited definition, we allow `react-wrap-balancer`'s children to match any custom overrides of the React types.