### PR TITLE
fix: Make sure relayout func handles incorrect input safely

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,7 +31,9 @@ declare global {
 const relayout: RelayoutFn = (id, ratio, wrapper) => {
   wrapper =
     wrapper || document.querySelector<WrapperElement>(`[data-br="${id}"]`)
-  const container = wrapper.parentElement
+  const container = wrapper?.parentElement
+
+  if (!container) { return; }
 
   const update = (width: number) => (wrapper.style.maxWidth = width + 'px')
 


### PR DESCRIPTION
For some reason, I see lots of e is null error.

<img width="1189" alt="截圖 2023-10-20 下午1 38 24" src="https://github.com/shuding/react-wrap-balancer/assets/16474/a43836ba-c5fa-4074-a391-22dd2fb90ed6">

And found out that it is because the element does not exist in the DOM tree while the function is executing.
So add a simple guard to prevent the unexpected error log.