### PR TITLE
Stop spreading `as` prop onto root element

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -186,13 +186,14 @@ const Balancer = <ElementType extends React.ElementType = React.ElementType>({
   preferNative,
   nonce,
   children,
+  as,
   ...props
 }: BalancerProps<ElementType>) => {
   const id = useId()
   const wrapperRef = React.useRef<WrapperElement>()
   const contextValue = React.useContext(BalancerContext)
   const preferNativeBalancing = preferNative ?? contextValue.preferNative
-  const Wrapper: React.ElementType = props.as || 'span'
+  const Wrapper: React.ElementType = as || 'span'
 
   // Re-balance on content change and on mount/hydration.
   useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
Previously, the `as` prop was spread onto the component it defines, so we get:

```tsx
<p as="p">
<span as="span">
```

<img width="81" alt="image" src="https://github.com/shuding/react-wrap-balancer/assets/15332326/ca8f7bdc-b273-49c7-86de-06497bc7bb30">

I destructured it to keep the resulting DOM clean.

